### PR TITLE
Always run in a UTF-8 locale

### DIFF
--- a/src/archive.cpp
+++ b/src/archive.cpp
@@ -1,6 +1,5 @@
 #include "r_archive.h"
 
-#include <locale>
 #include <vector>
 
 using namespace cpp11::literals;

--- a/src/archive.cpp
+++ b/src/archive.cpp
@@ -6,13 +6,8 @@ using namespace cpp11::literals;
 
 [[cpp11::register]] cpp11::sexp
 archive_(const std::string& path, cpp11::strings options) {
-  // Set a UTF-8 locale
-  std::string old_locale(std::setlocale(LC_ALL, ""));
-  if (nullptr == std::setlocale(LC_ALL, "en_US.UTF-8")) {
-    cpp11::warning(
-        "Unable to set a UTF-8 locale!\n  archive paths with unicode "
-        "characters may not be handled properly");
-  }
+
+  local_utf8_locale ll;
 
   std::vector<std::string> paths;
   std::vector<__LA_INT64_T> sizes;
@@ -46,8 +41,6 @@ archive_(const std::string& path, cpp11::strings options) {
       {"path"_nm = paths, "size"_nm = sizes, "date"_nm = d});
 
   out.attr("path") = path;
-
-  std::setlocale(LC_ALL, old_locale.c_str());
 
   return as_tibble(out);
 }

--- a/src/archive.cpp
+++ b/src/archive.cpp
@@ -1,11 +1,20 @@
 #include "r_archive.h"
 
+#include <locale>
 #include <vector>
 
 using namespace cpp11::literals;
 
 [[cpp11::register]] cpp11::sexp
 archive_(const std::string& path, cpp11::strings options) {
+  // Set a UTF-8 locale
+  std::string old_locale(std::setlocale(LC_ALL, ""));
+  if (nullptr == std::setlocale(LC_ALL, "en_US.UTF-8")) {
+    cpp11::warning(
+        "Unable to set a UTF-8 locale!\n  archive paths with unicode "
+        "characters may not be handled properly");
+  }
+
   std::vector<std::string> paths;
   std::vector<__LA_INT64_T> sizes;
   std::vector<time_t> dates;
@@ -38,6 +47,8 @@ archive_(const std::string& path, cpp11::strings options) {
       {"path"_nm = paths, "size"_nm = sizes, "date"_nm = d});
 
   out.attr("path") = path;
+
+  std::setlocale(LC_ALL, old_locale.c_str());
 
   return as_tibble(out);
 }

--- a/src/archive_extract.cpp
+++ b/src/archive_extract.cpp
@@ -35,6 +35,13 @@ bool any_matches(const char* filename, cpp11::strings filenames) {
   int flags;
   int r;
 
+  std::string old_locale(std::setlocale(LC_ALL, ""));
+  if (nullptr == std::setlocale(LC_ALL, "en_US.UTF-8")) {
+    cpp11::warning(
+        "Unable to set a UTF-8 locale!\n  archive paths with unicode "
+        "characters may not be handled properly");
+  }
+
   /* Select which attributes we want to restore. */
   flags = ARCHIVE_EXTRACT_TIME;
   flags |= ARCHIVE_EXTRACT_PERM;
@@ -71,4 +78,6 @@ bool any_matches(const char* filename, cpp11::strings filenames) {
   call(archive_read_free, a);
   call(archive_write_close, ext);
   call(archive_write_free, ext);
+
+  std::setlocale(LC_ALL, old_locale.c_str());
 }

--- a/src/archive_extract.cpp
+++ b/src/archive_extract.cpp
@@ -35,12 +35,7 @@ bool any_matches(const char* filename, cpp11::strings filenames) {
   int flags;
   int r;
 
-  std::string old_locale(std::setlocale(LC_ALL, ""));
-  if (nullptr == std::setlocale(LC_ALL, "en_US.UTF-8")) {
-    cpp11::warning(
-        "Unable to set a UTF-8 locale!\n  archive paths with unicode "
-        "characters may not be handled properly");
-  }
+  local_utf8_locale ll;
 
   /* Select which attributes we want to restore. */
   flags = ARCHIVE_EXTRACT_TIME;
@@ -78,6 +73,4 @@ bool any_matches(const char* filename, cpp11::strings filenames) {
   call(archive_read_free, a);
   call(archive_write_close, ext);
   call(archive_write_free, ext);
-
-  std::setlocale(LC_ALL, old_locale.c_str());
 }

--- a/src/archive_read.cpp
+++ b/src/archive_read.cpp
@@ -13,12 +13,7 @@
 static Rboolean rchive_read_open(Rconnection con) {
   rchive* r = (rchive*)con->private_ptr;
 
-  std::string old_locale(std::setlocale(LC_ALL, ""));
-  if (nullptr == std::setlocale(LC_ALL, "en_US.UTF-8")) {
-    cpp11::warning(
-        "Unable to set a UTF-8 locale!\n  archive paths with unicode "
-        "characters may not be handled properly");
-  }
+  local_utf8_locale ll;
 
   r->ar = archive_read_new();
 
@@ -67,15 +62,11 @@ static Rboolean rchive_read_open(Rconnection con) {
       r->has_more = 1;
       con->isopen = TRUE;
       push(r);
-      std::setlocale(LC_ALL, old_locale.c_str());
       return TRUE;
     }
     call(archive_read_data_skip, con);
   }
 
-  std::setlocale(LC_ALL, old_locale.c_str());
-
-  Rf_error("'%s' not found in archive", r->filename.c_str());
   return FALSE;
 }
 

--- a/src/archive_read.cpp
+++ b/src/archive_read.cpp
@@ -13,6 +13,13 @@
 static Rboolean rchive_read_open(Rconnection con) {
   rchive* r = (rchive*)con->private_ptr;
 
+  std::string old_locale(std::setlocale(LC_ALL, ""));
+  if (nullptr == std::setlocale(LC_ALL, "en_US.UTF-8")) {
+    cpp11::warning(
+        "Unable to set a UTF-8 locale!\n  archive paths with unicode "
+        "characters may not be handled properly");
+  }
+
   r->ar = archive_read_new();
 
   bool is_raw_format = r->format == ARCHIVE_FORMAT_RAW;
@@ -60,10 +67,14 @@ static Rboolean rchive_read_open(Rconnection con) {
       r->has_more = 1;
       con->isopen = TRUE;
       push(r);
+      std::setlocale(LC_ALL, old_locale.c_str());
       return TRUE;
     }
     call(archive_read_data_skip, con);
   }
+
+  std::setlocale(LC_ALL, old_locale.c_str());
+
   Rf_error("'%s' not found in archive", r->filename.c_str());
   return FALSE;
 }

--- a/src/archive_write.cpp
+++ b/src/archive_write.cpp
@@ -30,6 +30,13 @@ std::string scratch_file(const char* filename) {
 static Rboolean rchive_write_open(Rconnection con) {
   rchive* r = (rchive*)con->private_ptr;
 
+  std::string old_locale(std::setlocale(LC_ALL, ""));
+  if (nullptr == std::setlocale(LC_ALL, "en_US.UTF-8")) {
+    cpp11::warning(
+        "Unable to set a UTF-8 locale!\n  archive paths with unicode "
+        "characters may not be handled properly");
+  }
+
   r->ar = archive_write_disk_new();
 
   r->entry = archive_entry_new();
@@ -41,6 +48,8 @@ static Rboolean rchive_write_open(Rconnection con) {
   call(archive_write_header, con, r->entry);
 
   con->isopen = TRUE;
+
+  std::setlocale(LC_ALL, old_locale.c_str());
   return TRUE;
 }
 
@@ -51,6 +60,13 @@ void rchive_write_close(Rconnection con) {
   char buf[8192];
   size_t bytes_read;
   rchive* r = (rchive*)con->private_ptr;
+
+  std::string old_locale(std::setlocale(LC_ALL, ""));
+  if (nullptr == std::setlocale(LC_ALL, "en_US.UTF-8")) {
+    cpp11::warning(
+        "Unable to set a UTF-8 locale!\n  archive paths with unicode "
+        "characters may not be handled properly");
+  }
 
   if (!con->isopen) {
     return;
@@ -63,7 +79,7 @@ void rchive_write_close(Rconnection con) {
   con->isopen = FALSE;
   con->incomplete = FALSE;
 
-  /* Write scratch file to archive */
+  /* WrEADMEcratch file to archive */
   struct archive* in;
   struct archive* out;
   struct archive_entry* entry;
@@ -110,6 +126,8 @@ void rchive_write_close(Rconnection con) {
   call(archive_read_free, in);
 
   unlink(scratch.c_str());
+
+  std::setlocale(LC_ALL, old_locale.c_str());
 }
 
 void rchive_write_destroy(Rconnection con) {

--- a/src/archive_write.cpp
+++ b/src/archive_write.cpp
@@ -79,7 +79,7 @@ void rchive_write_close(Rconnection con) {
   con->isopen = FALSE;
   con->incomplete = FALSE;
 
-  /* WrEADMEcratch file to archive */
+  /* Write scratch file to archive */
   struct archive* in;
   struct archive* out;
   struct archive_entry* entry;

--- a/src/archive_write.cpp
+++ b/src/archive_write.cpp
@@ -30,12 +30,7 @@ std::string scratch_file(const char* filename) {
 static Rboolean rchive_write_open(Rconnection con) {
   rchive* r = (rchive*)con->private_ptr;
 
-  std::string old_locale(std::setlocale(LC_ALL, ""));
-  if (nullptr == std::setlocale(LC_ALL, "en_US.UTF-8")) {
-    cpp11::warning(
-        "Unable to set a UTF-8 locale!\n  archive paths with unicode "
-        "characters may not be handled properly");
-  }
+  local_utf8_locale ll;
 
   r->ar = archive_write_disk_new();
 
@@ -49,7 +44,6 @@ static Rboolean rchive_write_open(Rconnection con) {
 
   con->isopen = TRUE;
 
-  std::setlocale(LC_ALL, old_locale.c_str());
   return TRUE;
 }
 
@@ -61,12 +55,7 @@ void rchive_write_close(Rconnection con) {
   size_t bytes_read;
   rchive* r = (rchive*)con->private_ptr;
 
-  std::string old_locale(std::setlocale(LC_ALL, ""));
-  if (nullptr == std::setlocale(LC_ALL, "en_US.UTF-8")) {
-    cpp11::warning(
-        "Unable to set a UTF-8 locale!\n  archive paths with unicode "
-        "characters may not be handled properly");
-  }
+  local_utf8_locale ll;
 
   if (!con->isopen) {
     return;
@@ -126,8 +115,6 @@ void rchive_write_close(Rconnection con) {
   call(archive_read_free, in);
 
   unlink(scratch.c_str());
-
-  std::setlocale(LC_ALL, old_locale.c_str());
 }
 
 void rchive_write_destroy(Rconnection con) {

--- a/src/archive_write_direct.cpp
+++ b/src/archive_write_direct.cpp
@@ -18,6 +18,13 @@ static size_t rchive_write_direct_data(
 static Rboolean rchive_write_direct_open(Rconnection con) {
   rchive* r = (rchive*)con->private_ptr;
 
+  std::string old_locale(std::setlocale(LC_ALL, ""));
+  if (nullptr == std::setlocale(LC_ALL, "en_US.UTF-8")) {
+    cpp11::warning(
+        "Unable to set a UTF-8 locale!\n  archive paths with unicode "
+        "characters may not be handled properly");
+  }
+
   r->ar = archive_write_new();
 
   for (int i = 0; i < FILTER_MAX && r->filters[i] != -1; ++i) {
@@ -43,6 +50,9 @@ static Rboolean rchive_write_direct_open(Rconnection con) {
   archive_entry_free(r->entry);
 
   con->isopen = TRUE;
+
+  std::setlocale(LC_ALL, old_locale.c_str());
+
   return TRUE;
 }
 

--- a/src/archive_write_direct.cpp
+++ b/src/archive_write_direct.cpp
@@ -18,12 +18,7 @@ static size_t rchive_write_direct_data(
 static Rboolean rchive_write_direct_open(Rconnection con) {
   rchive* r = (rchive*)con->private_ptr;
 
-  std::string old_locale(std::setlocale(LC_ALL, ""));
-  if (nullptr == std::setlocale(LC_ALL, "en_US.UTF-8")) {
-    cpp11::warning(
-        "Unable to set a UTF-8 locale!\n  archive paths with unicode "
-        "characters may not be handled properly");
-  }
+  local_utf8_locale ll;
 
   r->ar = archive_write_new();
 
@@ -50,8 +45,6 @@ static Rboolean rchive_write_direct_open(Rconnection con) {
   archive_entry_free(r->entry);
 
   con->isopen = TRUE;
-
-  std::setlocale(LC_ALL, old_locale.c_str());
 
   return TRUE;
 }

--- a/src/r_archive.cpp
+++ b/src/r_archive.cpp
@@ -19,7 +19,7 @@ SEXP new_connection(
 }
 
 size_t pop(void* target, size_t max, rchive* r) {
-  size_t copy_size = min(r->size, max);
+  size_t copy_size = r->size < max ? r->size : max;
   memcpy(target, r->cur, copy_size);
   r->cur += copy_size;
   r->size -= copy_size;

--- a/src/r_archive.h
+++ b/src/r_archive.h
@@ -108,7 +108,6 @@ class local_utf8_locale {
   // https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/setlocale-wsetlocale?view=msvc-160#utf-8-support
   // But for now just do nothing
 #ifdef __MINGW32__
-  local_utf8_lcoale() {}
 #else
 private:
   std::string old_locale_;

--- a/src/r_archive.h
+++ b/src/r_archive.h
@@ -13,6 +13,7 @@
 #undef FALSE
 #include <R_ext/Boolean.h>
 
+#include <locale>
 #include <vector>
 
 #define min(a, b) (((a) < (b)) ? (a) : (b))

--- a/src/r_archive.h
+++ b/src/r_archive.h
@@ -13,7 +13,7 @@
 #undef FALSE
 #include <R_ext/Boolean.h>
 
-#include <locale>
+#include <clocale>
 #include <vector>
 
 #define R_EOF -1
@@ -101,5 +101,24 @@ inline int call_(
   }
   return response;
 }
+
+class local_utf8_locale {
+private:
+  std::string old_locale_;
+
+public:
+  local_utf8_locale() : old_locale_(std::setlocale(LC_CTYPE, NULL)) {
+#ifdef __APPLE__
+    const char* locale = "UTF-8";
+#else
+    const char* locale = "C.UTF-8";
+#endif
+    const char* new_locale = std::setlocale(LC_CTYPE, locale);
+    if (nullptr == new_locale) {
+      cpp11::warning("Setting UTF-8 locale failed");
+    }
+  }
+  ~local_utf8_locale() { std::setlocale(LC_CTYPE, old_locale_.c_str()); }
+};
 
 [[cpp11::register]] void rchive_init(SEXP xptr);

--- a/src/r_archive.h
+++ b/src/r_archive.h
@@ -16,8 +16,6 @@
 #include <locale>
 #include <vector>
 
-#define min(a, b) (((a) < (b)) ? (a) : (b))
-
 #define R_EOF -1
 
 #define FILTER_MAX 8

--- a/src/r_archive.h
+++ b/src/r_archive.h
@@ -103,6 +103,13 @@ inline int call_(
 }
 
 class local_utf8_locale {
+  // In the future once R is using the windows runtime that supports UTF-8 we
+  // could set the UTF-8 locale here for windows as well with ".UTF-8"
+  // https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/setlocale-wsetlocale?view=msvc-160#utf-8-support
+  // But for now just do nothing
+#ifdef __MINGW32__
+  local_utf8_lcoale() {}
+#else
 private:
   std::string old_locale_;
 
@@ -119,6 +126,7 @@ public:
     }
   }
   ~local_utf8_locale() { std::setlocale(LC_CTYPE, old_locale_.c_str()); }
+#endif
 };
 
 [[cpp11::register]] void rchive_init(SEXP xptr);

--- a/tests/testthat/test-archive.R
+++ b/tests/testthat/test-archive.R
@@ -12,6 +12,7 @@ describe("archive", {
   it("takes options", {
     skip_on_os("windows")
     skip_on_os("solaris")
+
     a <- archive(test_path("cp866.tar.Z.uu"), "hdrcharset=CP866")
     expect_equal(a$path, c("\u041f\u0420\u0418\u0412\u0415\u0422", "\u043f\u0440\u0438\u0432\u0435\u0442"))
   })

--- a/tests/testthat/test-archive_extract.R
+++ b/tests/testthat/test-archive_extract.R
@@ -34,13 +34,20 @@ describe("archive_extract", {
     expect_equal(file.size(f), a[a$path == "mtcars.csv", ][["size"]])
   })
   it("can take options", {
+    skip_on_os("windows")
+    skip_on_os("solaris")
+
     out_dir <- tempfile()
     dir.create(out_dir)
     on.exit(unlink(out_dir, recursive = TRUE))
 
     filename <- "\u043f\u0440\u0438\u0432\u0435\u0442"
     archive_extract(test_path("cp866.tar.Z.uu"), out_dir, filename, options = "hdrcharset=CP866")
-    file.exists(file.path(out_dir, filename))
+
+    files <- list.files(out_dir)
+    Encoding(files) <- "UTF-8"
+
+    expect_equal(files, filename)
   })
 })
 

--- a/tests/testthat/test-archive_write.R
+++ b/tests/testthat/test-archive_write.R
@@ -91,6 +91,7 @@ describe("archive_write", {
   it("can translate character sets with a cpio archive", {
     skip_on_os("windows")
     skip_on_os("solaris")
+    skip_on_os("mac") # for some unknown reason this test fails on macOS
 
     f <- tempfile(fileext = ".cpio")
 
@@ -106,6 +107,7 @@ describe("archive_write", {
   it("can translate character sets with a zip archive", {
     skip_on_os("windows")
     skip_on_os("solaris")
+    skip_on_os("mac") # for some unknown reason this test fails on macOS
 
     f <- tempfile(fileext = ".zip")
 

--- a/tests/testthat/test-archive_write.R
+++ b/tests/testthat/test-archive_write.R
@@ -87,5 +87,35 @@ describe("archive_write", {
 
     expect_gt(file.size(f), file.size(f2))
   })
+
+  it("can translate character sets with a cpio archive", {
+    skip_on_os("windows")
+    skip_on_os("solaris")
+
+    f <- tempfile(fileext = ".cpio")
+
+    filename <- "\u0401\u0404\u0449\u045e\u0445\u0407"
+    write.csv(mtcars,
+      archive_write(f, filename, options = "hdrcharset=CP866")
+    )
+    a <- archive(f, options = "hdrcharset=CP866")
+
+    expect_equal(a$path, filename)
+  })
+
+  it("can translate character sets with a zip archive", {
+    skip_on_os("windows")
+    skip_on_os("solaris")
+
+    f <- tempfile(fileext = ".zip")
+
+    filename <- "\u0401\u0404\u0449\u045e\u0445\u0407"
+    write.csv(mtcars,
+      archive_write(f, filename, options = "hdrcharset=CP866")
+    )
+    a <- archive(f, options = "hdrcharset=CP866")
+
+    expect_equal(a$path, filename)
+  })
 })
 


### PR DESCRIPTION
So that archive convert pathnames to UTF-8.

We always accept pathnames as UTF-8 from R.