### PR TITLE
Fix rwinlib for ucrt toolchains

### DIFF
--- a/src/Makevars.ucrt
+++ b/src/Makevars.ucrt
@@ -1,0 +1,2 @@
+CRT=-ucrt
+include Makevars.win

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -2,8 +2,8 @@ PKG_CPPFLAGS= \
   -I../windows/libarchive-3.2.2/include -I.
 
 PKG_LIBS = \
-  -L../windows/libarchive-3.2.2/lib${R_ARCH} \
-  -larchive -lcrypto -lnettle -lregex -lexpat -llzo2 -llzma -llz4 -lbz2 -lz -liconv
+  -L../windows/libarchive-3.2.2/lib${R_ARCH}${CRT} \
+  -larchive -lcrypto -lnettle -lregex -lexpat -llzo2 -llzma -llz4 -lbz2 -lz -liconv -lbcrypt
 
 
 # Originally from https://github.com/cran/curl/blob/3897ba5203dee940e2ce40ac23a0d1106da93df6/src/Makevars.win


### PR DESCRIPTION
Small tweak to fix the rwinlib flags for ucrt toolchains