### PR TITLE
Fix unterminated progress bars

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 * Fix UBSAN error related to the progress bar initialization (#55)
 
-* Fix unterminated progress bars in `archive_extract()`, `archive_write()` and friends (#60, @salim-b)
+* Fix unterminated progress bars in `archive_write()` and friends (#60, @salim-b)
 
 # archive 1.1.1
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 * Fix UBSAN error related to the progress bar initialization (#55)
 
+* Fix unterminated progress bars in `archive_extract()`, `archive_write()` and friends (#60, @salim-b)
+
 # archive 1.1.1
 
 * `archive_extract()` now returns the extracted files (invisibly) (#50)

--- a/src/archive_extract.cpp
+++ b/src/archive_extract.cpp
@@ -32,8 +32,6 @@ static int copy_data(
 
     call(archive_write_data_block, aw, buff, size, offset);
   }
-
-  cli_progress_done(progress_bar);
 }
 
 template <typename C> std::vector<R_xlen_t> as_file_index(const C& in) {

--- a/src/archive_extract.cpp
+++ b/src/archive_extract.cpp
@@ -32,6 +32,8 @@ static int copy_data(
 
     call(archive_write_data_block, aw, buff, size, offset);
   }
+
+  cli_progress_done(progress_bar);
 }
 
 template <typename C> std::vector<R_xlen_t> as_file_index(const C& in) {

--- a/src/archive_write_files.cpp
+++ b/src/archive_write_files.cpp
@@ -70,5 +70,7 @@ const char* const pb_format =
   }
   call(archive_write_free, a);
 
+  cli_progress_done(progress_bar);
+
   return R_NilValue;
 }


### PR DESCRIPTION
Progress bars in `archive_write()` and friends were not terminated before.