### PR TITLE
Show libarchive versions in CMD-check output

### DIFF
--- a/R/archive.R
+++ b/R/archive.R
@@ -157,3 +157,12 @@ libarchive_libzstd_version <- function() {
   }
   package_version("0.0.0")
 }
+
+print_versions <- function(){
+  cat("Linked to:\n")
+  cat("libarchive", as.character(libarchive_version()), '\n')
+  cat("zlib", as.character(libarchive_zlib_version()), '\n')
+  cat("lzma", as.character(libarchive_liblzma_version()), '\n')
+  cat("bzlib", as.character(libarchive_bzlib_version()), '\n')
+  cat("zsstd", as.character(libarchive_libzstd_version()), '\n')
+}

--- a/tests/version.R
+++ b/tests/version.R
@@ -1,0 +1,1 @@
+archive:::print_versions()

--- a/tests/version.Rout.save
+++ b/tests/version.Rout.save
@@ -1,0 +1,19 @@
+
+R version 3.5.3 (2019-03-11) -- "Great Truth"
+Copyright (C) 2019 The R Foundation for Statistical Computing
+Platform: x86_64-apple-darwin15.6.0 (64-bit)
+
+R is free software and comes with ABSOLUTELY NO WARRANTY.
+You are welcome to redistribute it under certain conditions.
+Type 'license()' or 'licence()' for distribution details.
+
+R is a collaborative project with many contributors.
+Type 'contributors()' for more information and
+'citation()' on how to cite R or R packages in publications.
+
+Type 'demo()' for some demos, 'help()' for on-line help, or
+'help.start()' for an HTML browser interface to help.
+Type 'q()' to quit R.
+
+> archive:::print_versions()
+>


### PR DESCRIPTION
This prints the version of libarchive libraries during the CMD check run. This can be very useful for debugging if some issue appears on CRAN or CI. I do this for most of my packages, e.g. https://cran.r-project.org/web/checks/check_results_V8.html