### PR TITLE
Resolve problem when building archive in conda

### DIFF
--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,10 +1,13 @@
 .onLoad <- function(libname, pkgname) {
-  lib_path <- list.files(paste0(libname, "/archive/lib"), pattern="libconnection.*", full.names=TRUE)
+  lib_path <- list.files(paste0(libname, "/archive/lib/", .Platform$r_arch), pattern="libconnection.*", full.names=TRUE)
+
+print( list.files(paste0(libname, "/archive/lib", .Platform$r_arch) ))
+
   res <- dyn.load(lib_path)
   rchive_init(res$new_connection$address, res$read_connection$address)
 }
 
 .onUnload <- function(libname) {
-  lib_path <- list.files(paste0(libname, "/lib"), pattern="libconnection.*", full.names=TRUE)
+  lib_path <- list.files(paste0(libname, "/lib/", .Platform$r_arch), pattern="libconnection.*", full.names=TRUE)
   dyn.unload(lib_path)
 }

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,8 +1,5 @@
 .onLoad <- function(libname, pkgname) {
   lib_path <- list.files(paste0(libname, "/archive/lib/", .Platform$r_arch), pattern="libconnection.*", full.names=TRUE)
-
-print( list.files(paste0(libname, "/archive/lib", .Platform$r_arch) ))
-
   res <- dyn.load(lib_path)
   rchive_init(res$new_connection$address, res$read_connection$address)
 }

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,11 +1,10 @@
 .onLoad <- function(libname, pkgname) {
   lib_path <- list.files(paste0(libname, "/archive/lib"), pattern="libconnection.*", full.names=TRUE)
-
   res <- dyn.load(lib_path)
   rchive_init(res$new_connection$address, res$read_connection$address)
 }
 
 .onUnload <- function(libname) {
-  lib_path <- list.files(paste0(libname, "/archive/lib"), pattern="libconnection.*", full.names=TRUE)
+  lib_path <- list.files(paste0(libname, "/lib"), pattern="libconnection.*", full.names=TRUE)
   dyn.unload(lib_path)
 }

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,11 +1,11 @@
 .onLoad <- function(libname, pkgname) {
-  lib_path <- system.file("lib", .Platform$r_arch, paste0("libconnection", .Platform$dynlib.ext), package = "archive")
-  res <- dyn.load(lib_path)
+  lib_path <- list.files(paste0(libname, "/archive/lib"), pattern="libconnection.*", full.names=TRUE)
 
+  res <- dyn.load(lib_path)
   rchive_init(res$new_connection$address, res$read_connection$address)
 }
 
 .onUnload <- function(libname) {
-  lib_path <- system.file("lib", .Platform$r_arch, paste0("libconnection", .Platform$dynlib.ext), package = "archive")
+  lib_path <- list.files(paste0(libname, "/archive/lib"), pattern="libconnection.*", full.names=TRUE)
   dyn.unload(lib_path)
 }


### PR DESCRIPTION
This PR addresses issue #78 where `lib_path` is empty when building in conda because `.Platform$dynlib.ext` is `.dylib` rather than `.so`. Not sure how to have `lib_path` fall back to `libconnection.dylib` rather than using pattern matching. Maybe @gaborcsardi has some ideas that I (or someone else) could incorporate?