### PR TITLE
archive_read.cpp: unbreak build for Big-endian platforms

### DIFF
--- a/src/archive_read.cpp
+++ b/src/archive_read.cpp
@@ -1,5 +1,26 @@
 #include "r_archive.h"
 
+/* Define BSWAP_32 on Big Endian systems */
+#ifdef WORDS_BIGENDIAN
+#if (defined(__sun) && defined(__SVR4))
+#include <sys/byteorder.h>
+#elif (defined(__APPLE__) && defined(__ppc__) || defined(__ppc64__))
+#include <libkern/OSByteOrder.h>
+#define BSWAP_32 OSSwapInt32
+#elif (defined(__OpenBSD__))
+#define BSWAP_32(x) swap32(x)
+#elif (defined(__NetBSD__))
+#include <sys/types.h>
+#include <machine/bswap.h>
+#define BSWAP_32(x) bswap32(x)
+#elif (defined(__GLIBC__))
+#include <byteswap.h>
+#define BSWAP_32(x) bswap_32(x)
+#elif (defined(_AIX))
+#define BSWAP_32(x) __builtin_bswap32(x)
+#endif
+#endif
+
 /* Read archives
  *
  * The custom R connection code was adapted from curl package by Jeroen Ooms


### PR DESCRIPTION
Fixes: https://github.com/r-lib/archive/issues/83
Signed-off-by: Sergey Fedorov <vital.had@gmail.com>

The `archive_read.cpp` code borrows from https://github.com/jeroen/curl/src/curl.c
However needed defines are forgotten, which unsurprisingly breaks the build.