### PR TITLE
unify Win32 macro to __MINGW32__

### DIFF
--- a/src/archive_extract.cpp
+++ b/src/archive_extract.cpp
@@ -61,7 +61,7 @@ static const char* strip_components(const char* p, int elements) {
   while (elements > 0) {
     switch (*p++) {
     case '/':
-#if defined(_WIN32)
+#if defined(__MINGW32__)
     case '\\': /* Support \ path sep on Windows ONLY. */
 #endif
       elements--;
@@ -80,7 +80,7 @@ static const char* strip_components(const char* p, int elements) {
   for (;;) {
     switch (*p) {
     case '/':
-#if defined(_WIN32)
+#if defined(__MINGW32__)
     case '\\': /* Support \ path sep on Windows ONLY. */
 #endif
       ++p;

--- a/src/archive_write_files.cpp
+++ b/src/archive_write_files.cpp
@@ -48,7 +48,7 @@ const char* const pb_format =
   for (std::string file : files) {
     stat(file.c_str(), &st);
     entry = archive_entry_new();
-#if defined(_WIN32) || (!defined(__GNUC__) && !defined(__clang__))
+#if defined(__MINGW32__)
     // there are quite many CRT dialects and passing struct stat to 3rdparty library could be unstable.
     archive_entry_set_size(entry, st.st_size);
     archive_entry_set_mtime(entry, st.st_mtime, 0);


### PR DESCRIPTION
We should use only one macro for such purpose