### PR TITLE
Short-cut extraction loop after extracting any specified files

### DIFF
--- a/src/archive_extract.cpp
+++ b/src/archive_extract.cpp
@@ -189,7 +189,12 @@ static const char* strip_components(const char* p, int elements) {
       copy_data(a, ext, progress_bar, total_read, num_extracted);
       call(archive_write_finish_entry, ext);
 
-      ++num_extracted;
+      num_extracted++;
+
+      if (num_extracted == file_indexes.size() ||
+          num_extracted == file_names.size()) {
+        break;
+      }
     }
   }
 


### PR DESCRIPTION
This is a specific fix for https://stackoverflow.com/questions/77390896/stop-the-execution-of-a-function-from-a-package-when-its-job-is-done -- if this is extracting files that are towards the front of the archive, run time can be greatly shortened.