### PR TITLE
Prepare linking on Windows for libxml2 depending on bcrypt.  Use pkg-config when available.

### DIFF
--- a/src/Makevars.ucrt
+++ b/src/Makevars.ucrt
@@ -1,7 +1,11 @@
 PKG_CPPFLAGS= -I. -Icpp11/include
 
-PKG_LIBS = -larchive -lxml2 -lcrypto -lnettle -lregex -lexpat -llzo2 \
-	   -llzma -llz4 -lbz2 -lz -lzstd -liconv -lws2_32
+ifeq (,$(shell pkg-config --version 2>/dev/null))
+    PKG_LIBS = -larchive -lxml2 -lcrypto -lnettle -lregex -lexpat -llzo2 \
+               -llzma -llz4 -lbz2 -lz -lzstd -liconv -lws2_32 -lbcrypt
+else
+    PKG_LIBS = $(shell pkg-config --libs libarchive)
+endif
 
 LIB_CON = ../inst/lib$(R_ARCH)/libconnection.dll
 


### PR DESCRIPTION
This patch prepares the linking on Windows for when libxml2 will require bcrypt, which is the case in upstream MXE and will likely happen, soon, in Rtools. When available, pkg-config is used instead to query the dependencies so that such updates are not necessary in the future.