### PR TITLE
Remove whitespace after operator""

### DIFF
--- a/src/cpp11/include/cpp11/R.hpp
+++ b/src/cpp11/include/cpp11/R.hpp
@@ -44,7 +44,7 @@
 namespace cpp11 {
 namespace literals {
 
-constexpr R_xlen_t operator"" _xl(unsigned long long int value) { return value; }
+constexpr R_xlen_t operator""_xl(unsigned long long int value) { return value; }
 
 }  // namespace literals
 

--- a/src/cpp11/include/cpp11/named_arg.hpp
+++ b/src/cpp11/include/cpp11/named_arg.hpp
@@ -39,7 +39,7 @@ class named_arg {
 
 namespace literals {
 
-inline named_arg operator"" _nm(const char* name, std::size_t) { return named_arg(name); }
+inline named_arg operator""_nm(const char* name, std::size_t) { return named_arg(name); }
 
 }  // namespace literals
 

--- a/src/cpp11/include/fmt/format.h
+++ b/src/cpp11/include/fmt/format.h
@@ -2749,7 +2749,7 @@ constexpr auto operator""_a()
   return {};
 }
 #else
-constexpr auto operator"" _a(const char* s, size_t) -> detail::udl_arg<char> {
+constexpr auto operator""_a(const char* s, size_t) -> detail::udl_arg<char> {
   return {s};
 }
 #endif
@@ -2764,7 +2764,7 @@ constexpr auto operator"" _a(const char* s, size_t) -> detail::udl_arg<char> {
     std::string message = "The answer is {}"_format(42);
   \endrst
  */
-constexpr auto operator"" _format(const char* s, size_t n)
+constexpr auto operator""_format(const char* s, size_t n)
     -> detail::udl_formatter<char> {
   return {{s, n}};
 }


### PR DESCRIPTION
The space after "" is deprecated since it creates ambiguity with reserved _-initial names per:

https://en.cppreference.com/w/cpp/language/user_literal