### PR TITLE
Add "Supported By Posit" badge to archive website

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -35,4 +35,5 @@ Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.2.1.9000
 SystemRequirements: libarchive: libarchive-dev (deb),
     libarchive-devel (rpm), libarchive (homebrew), libarchive_dev (csw)
+Config/Needs/website: tidyverse/tidytemplate
 Biarch: true

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,9 +1,12 @@
 url: https://archive.r-lib.org
 
 template:
+  package: tidytemplate
+  bootstrap: 5
   includes:
     in_header: |
       <script src="https://cdn.jsdelivr.net/gh/posit-dev/supported-by-posit/js/badge.min.js" data-max-height="43" data-light-bg="#666f76" data-light-fg="#f9f9f9"></script>
+      <script defer data-domain="archive.r-lib.org,all.r-lib.org,all.tidyverse.org" src="https://plausible.io/js/plausible.js"></script>
 
 authors:
   "Jim Hester":

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,5 +1,10 @@
 url: https://archive.r-lib.org
 
+template:
+  includes:
+    in_header: |
+      <script src="https://cdn.jsdelivr.net/gh/posit-dev/supported-by-posit/js/badge.min.js" data-max-height="43" data-light-bg="#666f76" data-light-fg="#f9f9f9"></script>
+
 authors:
   "Jim Hester":
     href: http://jimhester.com
@@ -8,27 +13,22 @@ development:
   mode: auto
 
 reference:
-  - title: Read and write archives using R connections.
-    desc: These functions deal with archive formats such as zip, 7zip, rar and
-      tar and return connection objects which can be used by many R input /
-      output functions.
-    contents:
-      - archive
-      - archive_read
-      - archive_write
+- title: Read and write archives using R connections.
+  desc: These functions deal with archive formats such as zip, 7zip, rar and tar and return connection objects which can be used by many R input / output functions.
+  contents:
+  - archive
+  - archive_read
+  - archive_write
 
-  - title: Extract files from archives and write existing files to archives.
-    desc: These functions create archives from a set of existing files or
-      extract some or all files from an archive to disk.
-    contents:
-      - archive_extract
-      - archive_write_files
-      - archive_write_dir
+- title: Extract files from archives and write existing files to archives.
+  desc: These functions create archives from a set of existing files or extract some or all files from an archive to disk.
+  contents:
+  - archive_extract
+  - archive_write_files
+  - archive_write_dir
 
-  - title: Read and Write files using R connections.
-    desc: These functions write or read a file filtered by one or more
-      compression algorithms or encoding filters supported by libarchive, such
-      as gzip, bzip2 and xz and return an R connection to that file.
-    contents:
-      - file_read
-      - file_write
+- title: Read and Write files using R connections.
+  desc: These functions write or read a file filtered by one or more compression algorithms or encoding filters supported by libarchive, such as gzip, bzip2 and xz and return an R connection to that file.
+  contents:
+  - file_read
+  - file_write

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -13,22 +13,27 @@ development:
   mode: auto
 
 reference:
-- title: Read and write archives using R connections.
-  desc: These functions deal with archive formats such as zip, 7zip, rar and tar and return connection objects which can be used by many R input / output functions.
-  contents:
-  - archive
-  - archive_read
-  - archive_write
+  - title: Read and write archives using R connections.
+    desc: These functions deal with archive formats such as zip, 7zip, rar and
+      tar and return connection objects which can be used by many R input /
+      output functions.
+    contents:
+      - archive
+      - archive_read
+      - archive_write
 
-- title: Extract files from archives and write existing files to archives.
-  desc: These functions create archives from a set of existing files or extract some or all files from an archive to disk.
-  contents:
-  - archive_extract
-  - archive_write_files
-  - archive_write_dir
+  - title: Extract files from archives and write existing files to archives.
+    desc: These functions create archives from a set of existing files or
+      extract some or all files from an archive to disk.
+    contents:
+      - archive_extract
+      - archive_write_files
+      - archive_write_dir
 
-- title: Read and Write files using R connections.
-  desc: These functions write or read a file filtered by one or more compression algorithms or encoding filters supported by libarchive, such as gzip, bzip2 and xz and return an R connection to that file.
-  contents:
-  - file_read
-  - file_write
+  - title: Read and Write files using R connections.
+    desc: These functions write or read a file filtered by one or more
+      compression algorithms or encoding filters supported by libarchive, such
+      as gzip, bzip2 and xz and return an R connection to that file.
+    contents:
+      - file_read
+      - file_write


### PR DESCRIPTION
## Overview

This PR adds the "Supported by Posit" badge to the archive website.

## Background

We've recently started adding a "Supported by Posit" badge across all Posit package websites to create a more cohesive brand presence. The badge appears on the far right of the top navigation bar or at the bottom of the hamburger menu. It links to Posit’s main website. @hadley is involved with this initiative.

The following websites already have the "Supported by Posit" badge: [ggplot2](https://ggplot2.tidyverse.org), [Great Tables](https://posit-dev.github.io/great-tables/articles/intro.html), [gt](https://gt.rstudio.com), [Plotnine](https://plotnine.org), [Pointblank](https://posit-dev.github.io/pointblank/), [pointblank](https://rstudio.github.io/pointblank/), and [Quarto](https://quarto.org).

See https://posit-dev.github.io/supported-by-posit/ for more information.

## Changes

- Added a line to `_pkgdown.yml` to include the JavaScript file
- Standardized indentation in `_pkgdown.yml`

## Screenshots

At 1200px browser width:

![Screenshot of archive website at 1200px browser width](https://posit-dev.github.io/supported-by-posit/screenshots/archive-1200.png)

At 992px browser width:

![Screenshot of archive website at 992px browser width](https://posit-dev.github.io/supported-by-posit/screenshots/archive-992.png)

At 991px browser width:

![Screenshot of archive website at 991px browser width](https://posit-dev.github.io/supported-by-posit/screenshots/archive-991.png)

